### PR TITLE
busybox: nslookup applet link with resolv if use glibc

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -98,6 +98,10 @@ endif
 
 LDLIBS += $(call BUSYBOX_IF_ENABLED,PAM,pam pam_misc pthread)
 
+ifeq ($(CONFIG_USE_GLIBC),y)
+  LDLIBS += $(call BUSYBOX_IF_ENABLED,NSLOOKUP,resolv)
+endif
+
 ifeq ($(BUILD_VARIANT),selinux)
   LDLIBS += selinux sepol
 endif


### PR DESCRIPTION
This fixed b36b8b6929c6d6b17edddfb4597cf6a26a991ed0
("busybox: remove nslookup_lede/openwrt.patch")

It is likely dropped by mistake, This add back the changes

Signed-off-by: Chen Minqiang <ptpt52@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
