### PR TITLE
uboot-mediatek: unifi6lr: mtd erase size must be aligned

### DIFF
--- a/package/boot/uboot-mediatek/patches/412-add-ubnt-unifi-6-lr.patch
+++ b/package/boot/uboot-mediatek/patches/412-add-ubnt-unifi-6-lr.patch
@@ -402,7 +402,7 @@
 +reset_factory=mtd erase nor0 0xc0000 0x10000 && reset
 +nor_read_production=mtd read nor0 $loadaddr 0x1000000 0x1000 && imsz $loadaddr image_size && mtd read nor0 $loadaddr 0x1000000 $image_size
 +nor_read_recovery=mtd read nor0 $loadaddr 0x120000 0x1000 && imsz $loadaddr image_size && mtd read nor0 $loadaddr 0x120000 $image_size
-+nor_write_production=mtd erase nor0 0x1000000 $filesize && mtd write nor0 $loadaddr 0x1000000 $filesize
++nor_write_production=mtd erase nor0 0x1000000 && mtd write nor0 $loadaddr 0x1000000 $filesize
 +nor_write_recovery=mtd erase nor0 0x120000 0xee0000 && mtd write nor0 $loadaddr 0x120000 $filesize
 +_init_env=setenv _init_env ; saveenv
 +_firstboot=setenv _firstboot ; run _switch_to_menu ; run ethaddr_factory ; run _init_env ; run boot_first


### PR DESCRIPTION
$filesize is likely not aligned to 0x10000, `mtd erase` with size $filesize would
cause failure.

This change drop specifying the size while erasing the production, to erase the
total partition.

Fixes: 43dad22025597cb535626757301e035187d02b25
("uboot-mediatek: unifi6lr: mtd erase before write to flash")

Signed-off-by: Chen Minqiang <ptpt52@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
