### PR TITLE
mediatek/ramips: add flow offload keep alive

### DIFF
--- a/target/linux/generic/pending-5.10/770-15-net-ethernet-mtk_eth_soc-add-support-for-initializin.patch
+++ b/target/linux/generic/pending-5.10/770-15-net-ethernet-mtk_eth_soc-add-support-for-initializin.patch
@@ -136,7 +136,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /* struct mtk_mac -	the structure that holds the info about the MACs of the
 --- /dev/null
 +++ b/drivers/net/ethernet/mediatek/mtk_ppe.c
-@@ -0,0 +1,511 @@
+@@ -0,0 +1,516 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/* Copyright (C) 2020 Felix Fietkau <nbd@nbd.name> */
 +
@@ -599,6 +599,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	val = FIELD_PREP(MTK_PPE_BIND_AGE1_DELTA_TCP_FIN, 1) |
 +	      FIELD_PREP(MTK_PPE_BIND_AGE1_DELTA_TCP, 7);
 +	ppe_w32(ppe, MTK_PPE_BIND_AGE1, val);
++
++	val = FIELD_PREP(MTK_PPE_KEEPALIVE_TIME, 1) |
++	      FIELD_PREP(MTK_PPE_KEEPALIVE_TIME_TCP, 1) |
++	      FIELD_PREP(MTK_PPE_KEEPALIVE_TIME_UDP, 1);
++	ppe_w32(ppe, MTK_PPE_KEEPALIVE, val);
 +
 +	val = MTK_PPE_BIND_LIMIT0_QUARTER | MTK_PPE_BIND_LIMIT0_HALF;
 +	ppe_w32(ppe, MTK_PPE_BIND_LIMIT0, val);

--- a/target/linux/generic/pending-5.4/770-15-net-ethernet-mediatek-mtk_eth_soc-add-support-for-in.patch
+++ b/target/linux/generic/pending-5.4/770-15-net-ethernet-mediatek-mtk_eth_soc-add-support-for-in.patch
@@ -134,7 +134,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /* struct mtk_mac -	the structure that holds the info about the MACs of the
 --- /dev/null
 +++ b/drivers/net/ethernet/mediatek/mtk_ppe.c
-@@ -0,0 +1,497 @@
+@@ -0,0 +1,502 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/* Copyright (C) 2020 Felix Fietkau <nbd@nbd.name> */
 +
@@ -583,6 +583,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	val = FIELD_PREP(MTK_PPE_BIND_AGE1_DELTA_TCP_FIN, 1) |
 +	      FIELD_PREP(MTK_PPE_BIND_AGE1_DELTA_TCP, 7);
 +	ppe_w32(ppe, MTK_PPE_BIND_AGE1, val);
++
++	val = FIELD_PREP(MTK_PPE_KEEPALIVE_TIME, 1) |
++	      FIELD_PREP(MTK_PPE_KEEPALIVE_TIME_TCP, 1) |
++	      FIELD_PREP(MTK_PPE_KEEPALIVE_TIME_UDP, 1);
++	ppe_w32(ppe, MTK_PPE_KEEPALIVE, val);
 +
 +	val = MTK_PPE_BIND_LIMIT0_QUARTER | MTK_PPE_BIND_LIMIT0_HALF;
 +	ppe_w32(ppe, MTK_PPE_BIND_LIMIT0, val);


### PR DESCRIPTION
This add back the code for flow offload keep alive setup
this code is missing since b59d5c8f0eebb6d15d7cefe487c17fad0ee4a524
("mediatek: rewrite flow offload code")

Tested: mt7621

Signed-off-by: Chen Minqiang <ptpt52@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
